### PR TITLE
Add preliminary amd-pstate governor support

### DIFF
--- a/src/slimbookbatterypreferences.py
+++ b/src/slimbookbatterypreferences.py
@@ -907,6 +907,13 @@ class SettingsGrid(BasePageGrid):
         (4, 'performance'),
         (5, 'conservative'),
     ]
+    AMD_PSTATE_GOV = [
+        (1, 'ondemand'),
+        (2, 'schedutil'),
+        (3, 'powersave'),
+        (4, 'performance'),
+        (5, 'conservative')
+    ]
 
     SECTION_MAPPING = {
         'ahorrodeenergia': {
@@ -994,6 +1001,7 @@ class SettingsGrid(BasePageGrid):
             'intel_pstate': INTEL_GOV,
             'acpi-cpufreq': CPUFREQ_GOV,
             'intel_cpufreq': CPUFREQ_GOV,
+            'amd-pstate': AMD_PSTATE_GOV
         },
         {
             'name': 'graphic',
@@ -1134,10 +1142,10 @@ class SettingsGrid(BasePageGrid):
         governor_driver = None
         
         for governor_driver in governors:
-            if governor_driver not in ['intel_pstate', 'acpi-cpufreq', 'intel_cpufreq']:
+            if governor_driver not in ['intel_pstate', 'acpi-cpufreq', 'intel_cpufreq', 'amd-pstate']:
                 governor_driver = None
                 break
-            
+        
         return governor_driver
 
     @staticmethod
@@ -1368,6 +1376,16 @@ class SettingsGrid(BasePageGrid):
                     active_mode = values.index('performance')
         elif governor in ['acpi-cpufreq', 'intel_cpufreq']:
             values = list(dict(self.CPUFREQ_GOV).values())
+            if gov_mode in values:
+                active_mode = values.index(gov_mode)
+            else:
+                # Setting default mode
+                if self.custom_file == 'ahorrodeenergia':
+                    active_mode = values.index('powersave')
+                else:
+                    active_mode = values.index('ondemand')
+        elif governor == 'amd-pstate':
+            values = list(dict(self.AMD_PSTATE_GOV).values())
             if gov_mode in values:
                 active_mode = values.index(gov_mode)
             else:


### PR DESCRIPTION
This is a pull request to add `amd-pstate` governor support to Slimbook Battery. The reason I had more issues in #70 was that the application did not recognize the governor my Slimbook Essential was using - it did not have information on that. I followed the code already in the file and added initial - experimental at best - support for it. This fixes my situation and makes Slimbook Battery usable on my system.

Hopefully this pull request fixes the issue. Feel free to ask additional questions or give criticism regarding the code. If you do not accept pull requests from external people, then feel free to discard this as well.