### PR TITLE
Fix pgrep length limit

### DIFF
--- a/bin/slimbookbattery
+++ b/bin/slimbookbattery
@@ -39,7 +39,7 @@ def main():
         sys.stderr.write("Slimbook Battery requires TLP\n")
         exit(1)
 
-    pgrep = subprocess.getoutput(f"pgrep -f slimbookbatterypreferences")
+    pgrep = subprocess.getoutput("pgrep -f slimbookbatterypreferences")
     num_proc_running = pgrep.split('\n')
     if len(num_proc_running) > 1:
         sys.stdout.write("Slimbook Battery is in execution\n")

--- a/bin/slimbookbattery
+++ b/bin/slimbookbattery
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import argparse
@@ -39,17 +39,14 @@ def main():
         sys.stderr.write("Slimbook Battery requires TLP\n")
         exit(1)
 
-    pgrep = subprocess.getoutput("pgrep slimbookbatterypreferences")
+    pgrep = subprocess.getoutput(f"pgrep -f slimbookbatterypreferences")
     num_proc_running = pgrep.split('\n')
     if len(num_proc_running) > 1:
         sys.stdout.write("Slimbook Battery is in execution\n")
     elif args.minimize:
-        indicator_py = os.path.join('/usr/share/slimbookbattery/src/slimbookbatteryindicator.py')
-        os.system('python3 {}'.format(indicator_py))
+        subprocess.run(['/usr/bin/env', 'python3', '/usr/share/slimbookbattery/src/slimbookbatteryindicator.py'])
     else:
-        preference_py = os.path.join('/usr/share/slimbookbattery/src/slimbookbatterypreferences.py')
-        os.system('python3 {}'.format(preference_py))
-
+        subprocess.run(['/usr/bin/env', 'python3', '/usr/share/slimbookbattery/src/slimbookbatterypreferences.py'])
 
 if __name__ == "__main__":
     main()

--- a/src/ac_power.py
+++ b/src/ac_power.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import configparser

--- a/src/slimbookbatteryindicator.py
+++ b/src/slimbookbatteryindicator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # Slimbook Battery

--- a/src/slimbookbatterypreferences.py
+++ b/src/slimbookbatterypreferences.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # Slimbook Battery

--- a/src/sudocommands.py
+++ b/src/sudocommands.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # Slimbook Battery

--- a/src/translations/comparer.py
+++ b/src/translations/comparer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import configparser, os, shutil, subprocess


### PR DESCRIPTION
This patch makes the program run in Debian and other systems. In them, pgrep has a limit of 15 characters, so the
"slimbookbatterypreferences" string is too long for it. This patch uses the -f parameter to fix this.

It also adds some extra fixes, like using /usr/bin/env in the shebang, and launching the childs with "subprocess.run", which removes the shell (this is also needed to make pgrep work, because with the -f parameter, it searches in all the command line, and since os.system() launches the process inside a shell, there would be at least two processes with that).

Fix https://github.com/Slimbook-Team/slimbookbattery/issues/96