### PR TITLE
deploy.sh: More fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ Run command:
 
 
 * ## From this repository-source   
-	Donwload entire repo. Navigate to it in a terminal. And run deploy.sh script:
+	Donwload entire repo. Navigate to it in a terminal. And run deploy.sh script as root:
 
-		./deploy.sh
+		sudo ./deploy.sh
 
-	It will deploy SlimbookBattery in your system, check and install Python dependencies prepare all.
+	It will check and install all system and Python dependencies, and deploy SlimbookBattery in your system.
 <br />
 
 


### PR DESCRIPTION
- Root is needed for `./src/check_config.py` too in the end. Thus, mandate running deploy.sh with root, and remove all `sudo` uses.
- Use `apt-get` instead of `apt`, since latter doesn't have stable CLI interface.
- Separate `eval` from `if` statement to correctly check return code.
- Remove `/usr/bin/slimbookbattery*` symlinks when clearing up previous installation.
- Exit on error when doing Slimbook Battery installation.
- Do not make `changelog` folder as it will be a file.
- Make `custom` and `default` folders.