### PR TITLE
Fix English mistake

### DIFF
--- a/src/slimbookbatterypreferences.py
+++ b/src/slimbookbatterypreferences.py
@@ -804,7 +804,7 @@ class GeneralGrid(BasePageGrid):
         buttons_grid.set_name("radio_grid")
         self.grid.attach(buttons_grid, 0, row, 5, 3)
 
-        label = Gtk.Label(label=_("Actual energy mode:").upper())
+        label = Gtk.Label(label=_("Current energy mode:").upper())
         label.set_name("modes")
         buttons_grid.attach(label, 0, 0, 3, 1)
 

--- a/src/translations/ca/LC_MESSAGES/preferences.po
+++ b/src/translations/ca/LC_MESSAGES/preferences.po
@@ -74,7 +74,7 @@ msgid "Autostart application:"
 msgstr "Inici automàtic amb el sistema:"
 
 #: preferences.py:235
-msgid "Actual energy mode:"
+msgid "Current energy mode:"
 msgstr "Mode actual d'energia"
 
 #: preferences.py:264

--- a/src/translations/cn/LC_MESSAGES/preferences.po
+++ b/src/translations/cn/LC_MESSAGES/preferences.po
@@ -74,7 +74,7 @@ msgid "Autostart application:"
 msgstr "自动启动："
 
 #: preferences.py:235
-msgid "Actual energy mode:"
+msgid "Current energy mode:"
 msgstr "运行模式："
 
 #: preferences.py:264

--- a/src/translations/en/LC_MESSAGES/preferences.po
+++ b/src/translations/en/LC_MESSAGES/preferences.po
@@ -74,8 +74,8 @@ msgid "Autostart application:"
 msgstr "Autostart application:"
 
 #: preferences.py:235
-msgid "Actual energy mode:"
-msgstr "Actual energy mode:"
+msgid "Current energy mode:"
+msgstr "Current energy mode:"
 
 #: preferences.py:264
 msgid "Working mode in case of battery failure"

--- a/src/translations/es/LC_MESSAGES/preferences.po
+++ b/src/translations/es/LC_MESSAGES/preferences.po
@@ -74,7 +74,7 @@ msgid "Autostart application:"
 msgstr "Autoarranque con el sistema:"
 
 #: preferences.py:235
-msgid "Actual energy mode:"
+msgid "Current energy mode:"
 msgstr "Modo actual de energía:"
 
 #: preferences.py:264

--- a/src/translations/gl/LC_MESSAGES/preferences.po
+++ b/src/translations/gl/LC_MESSAGES/preferences.po
@@ -75,7 +75,7 @@ msgid "Autostart application:"
 msgstr "Iniciar co arrinque do sistema:"
 
 #: preferences.py:235
-msgid "Actual energy mode:"
+msgid "Current energy mode:"
 msgstr "Modo actual de enerxía:"
 
 #: preferences.py:264

--- a/src/translations/it/LC_MESSAGES/preferences.po
+++ b/src/translations/it/LC_MESSAGES/preferences.po
@@ -76,7 +76,7 @@ msgid "Autostart application:"
 msgstr "Avvio automatico:"
 
 #: preferences.py:235
-msgid "Actual energy mode:"
+msgid "Current energy mode:"
 msgstr "Modalità di energia effettiva:"
 
 #: preferences.py:264

--- a/src/translations/nl/LC_MESSAGES/preferences.po
+++ b/src/translations/nl/LC_MESSAGES/preferences.po
@@ -76,7 +76,7 @@ msgid "Autostart application:"
 msgstr "Automatisch opstarten:"
 
 #: preferences.py:235
-msgid "Actual energy mode:"
+msgid "Current energy mode:"
 msgstr "Huidige energiemodus:"
 
 #: preferences.py:264

--- a/src/translations/slimbookbatterypreferences.template.po
+++ b/src/translations/slimbookbatterypreferences.template.po
@@ -246,7 +246,7 @@ msgid "Learn more about TDP Controller"
 msgstr ""
 
 #: slimbookbatterypreferences.py:770
-msgid "Actual energy mode:"
+msgid "Current energy mode:"
 msgstr ""
 
 #: slimbookbatterypreferences.py:986


### PR DESCRIPTION
“Actualmente” translates to “current” in English. “Actual” is a false friend which means “de hecho”.

I didn’t test it. I think it should work because I replaced every occurence (the one in the code and the ones in every language file), but I’ll let people with an already prepared dev environment test it.

Note: I didn’t replace the screenshot in the README, which should be updated too.